### PR TITLE
fix: Update Cloudflare deployment to use wrangler-action@v3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,11 +61,8 @@ jobs:
         run: ls -la ./dist
           
       - name: Publish to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: andrewginns
-          directory: ./dist
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          wranglerVersion: '3'
+          command: pages deploy ./dist --project-name=andrewginns --compatibility-date=2024-09-23

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,4 +65,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ./dist --project-name=andrewginns --compatibility-date=2024-09-23
+          command: pages deploy ./dist --project-name=andrewginns --compatibility-date=2025-06-01


### PR DESCRIPTION
Replace deprecated cloudflare/pages-action@v1 with cloudflare/wrangler-action@v3
to resolve "Unknown internal error" deployment failures.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>