### PR TITLE
Fix CSP blocking plotly charts on merbench page

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,7 +5,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), magnetometer=(), gyroscope=(), fullscreen=(self), accelerometer=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https: blob:; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://api.github.com https://api.rss2json.com; media-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.plot.ly https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https: blob:; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://api.github.com https://api.rss2json.com; media-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
 
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary
- Fixes Content Security Policy blocking plotly.js and Cloudflare insights scripts in production
- Adds `https://cdn.plot.ly` and `https://static.cloudflareinsights.com` to script-src directive
- Resolves merbench page chart loading failures on Cloudflare Pages deployment

## Changes
- Updated `/public/_headers` CSP configuration to allow required external scripts
- Maintains security while enabling necessary functionality

## Test plan
- [x] Build passes successfully
- [x] CSP changes validated in dist/_headers
- [ ] Deploy to staging/production and verify charts load correctly
- [ ] Confirm no CSP console errors