### PR TITLE
feat: Add 'Price per Success' column to Merbench leaderboard

### DIFF
--- a/src/components/merbench/LeaderboardTable.astro
+++ b/src/components/merbench/LeaderboardTable.astro
@@ -36,6 +36,9 @@ const costRange = maxCost - minCost;
           <th class="sortable" data-sort-key="Avg_Cost" data-sort-type="number">
             Avg Cost/Run <span class="sort-indicator"></span>
           </th>
+          <th class="sortable" data-sort-key="Price_per_Success" data-sort-type="number">
+            Price/Success <span class="sort-indicator"></span>
+          </th>
           <th class="sortable" data-sort-key="Avg_Duration" data-sort-type="number">
             Avg Duration <span class="sort-indicator"></span>
           </th>
@@ -89,6 +92,9 @@ const costRange = maxCost - minCost;
                     ${(entry.Avg_Cost || calculateCost(entry.Avg_Tokens)).toFixed(4)}
                   </span>
                 </div>
+              </td>
+              <td class="cost">
+                {entry.Price_per_Success != null ? `$${entry.Price_per_Success.toFixed(4)}` : 'N/A'}
               </td>
               <td class="duration">{entry.Avg_Duration.toFixed(2)}s</td>
               <td class="tokens">{entry.Avg_Tokens.toLocaleString()}</td>

--- a/src/lib/merbench-types.ts
+++ b/src/lib/merbench-types.ts
@@ -18,6 +18,7 @@ export interface LeaderboardEntry {
   Avg_Cost?: number;
   Avg_Input_Cost?: number;
   Avg_Output_Cost?: number;
+  Price_per_Success?: number;
   Runs: number;
   Provider: string;
 }

--- a/src/lib/merbench.ts
+++ b/src/lib/merbench.ts
@@ -94,17 +94,24 @@ export const getFilteredData = (
   });
 
   const filteredLeaderboard = Object.values(modelStats)
-    .map((stats) => ({
-      Model: stats.Model,
-      Success_Rate: (stats.successCount / stats.totalRuns) * 100,
-      Avg_Duration: stats.totalDuration / stats.totalRuns,
-      Avg_Tokens: stats.totalTokens / stats.totalRuns,
-      Avg_Cost: stats.totalCost / stats.totalRuns,
-      Avg_Input_Cost: stats.totalInputCost / stats.totalRuns,
-      Avg_Output_Cost: stats.totalOutputCost / stats.totalRuns,
-      Runs: stats.totalRuns,
-      Provider: stats.Provider,
-    }))
+    .map((stats) => {
+      const successRate = stats.totalRuns > 0 ? (stats.successCount / stats.totalRuns) * 100 : 0;
+      const avgCost = stats.totalRuns > 0 ? stats.totalCost / stats.totalRuns : 0;
+      const pricePerSuccess = successRate > 0 ? avgCost / (successRate / 100) : null;
+
+      return {
+        Model: stats.Model,
+        Success_Rate: successRate,
+        Avg_Duration: stats.totalRuns > 0 ? stats.totalDuration / stats.totalRuns : 0,
+        Avg_Tokens: stats.totalRuns > 0 ? stats.totalTokens / stats.totalRuns : 0,
+        Avg_Cost: avgCost,
+        Avg_Input_Cost: stats.totalRuns > 0 ? stats.totalInputCost / stats.totalRuns : 0,
+        Avg_Output_Cost: stats.totalRuns > 0 ? stats.totalOutputCost / stats.totalRuns : 0,
+        Price_per_Success: pricePerSuccess,
+        Runs: stats.totalRuns,
+        Provider: stats.Provider,
+      };
+    })
     .sort((a, b) => b.Success_Rate - a.Success_Rate);
 
   // Recalculate pareto data
@@ -280,8 +287,8 @@ export const sortLeaderboard = (
   direction: 'asc' | 'desc'
 ): LeaderboardEntry[] => {
   const sorted = [...data].sort((a, b) => {
-    let aVal: any;
-    let bVal: any;
+    let aVal: LeaderboardEntry[keyof LeaderboardEntry];
+    let bVal: LeaderboardEntry[keyof LeaderboardEntry];
 
     // Handle special cases for cost calculation
     if (sortKey === 'Avg_Cost') {

--- a/src/pages/merbench.astro
+++ b/src/pages/merbench.astro
@@ -14,6 +14,16 @@ import merbenchData from '../data/merbench_data.json';
 const data = merbenchData as MerbenchData;
 
 const { stats, leaderboard, config } = data;
+
+// Calculate Price_per_Success for the initial leaderboard data
+leaderboard.forEach((entry) => {
+  if (entry.Success_Rate > 0 && entry.Avg_Cost != null) {
+    entry.Price_per_Success = entry.Avg_Cost / (entry.Success_Rate / 100);
+  } else {
+    entry.Price_per_Success = null;
+  }
+});
+
 const formattedDescription = renderMarkdownToHTML(config.description);
 
 // Fetch last commit info for the merbench data file


### PR DESCRIPTION
This commit adds a new 'Price per Success' column to the leaderboard table on the Merbench page.

The 'Price per Success' is calculated as `Avg. Cost / Success Rate` and provides a more realistic measure of the cost to achieve a successful outcome, factoring in the cost of failed attempts.

The changes include:
- Updating the `LeaderboardTable.astro` component to add the new column.
- Updating the `merbench-types.ts` to include the new field in the `LeaderboardEntry` interface.
- Modifying `merbench.ts` to calculate the new metric when data is filtered.
- Modifying `merbench.astro` to calculate the new metric for the initial data load.