### PR TITLE
chore: Skip processing of Medium post titles

### DIFF
--- a/src/pages/writing.astro
+++ b/src/pages/writing.astro
@@ -190,6 +190,7 @@ if (mediumArticles.length > 0) {
   .post-preview h2 {
     font-size: 1.5rem;
     margin-bottom: 0.5rem;
+    text-transform: none;
   }
 
   .post-preview h2 a {


### PR DESCRIPTION
Prevent h2 allcaps titles for posts